### PR TITLE
ESD-5: Implement single source of truth for environment variables

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -1,0 +1,16 @@
+require('dotenv')
+  .config()
+
+import { AppConfiguration } from './models/configuration/AppConfiguration'
+
+const configuration = {
+  aws: {
+    region: process.env.AWS_REGION
+  },
+  logging: {
+    name: process.env.LOGGER_NAME,
+    level: process.env.LOGGER_LEVEL
+  }
+} as AppConfiguration
+
+export { configuration }

--- a/src/factories/LoggerFactory.ts
+++ b/src/factories/LoggerFactory.ts
@@ -1,6 +1,6 @@
 import * as Logger from 'bunyan'
 
-import { LoggerConfiguration } from '../models/LoggerConfiguration'
+import { LoggerConfiguration } from '../models/configuration/LoggerConfiguration'
 
 /**
  * Logger Factory creates named instances of loggers

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,17 @@
-import { LoggerFactory } from './factories/LoggerFactory'
-
-require('dotenv')
-  .config()
-
 import * as Ajv from 'ajv'
 
 import { DynamoDB } from 'aws-sdk'
 
 import { Version } from './lib/Version'
 import { Controller } from './Controller'
+import { configuration } from './Configuration'
 import { AJVValidator } from './lib/AJVValidator'
+import { LoggerFactory } from './factories/LoggerFactory'
 import { SchedulerService } from './services/SchedulerService'
 import { DynamoRepository } from './repositories/DynamoRepository'
-import { LoggerConfiguration } from './models/LoggerConfiguration'
 
 // Logger Factory
-const loggerConfig = {
-  name: process.env.LOGGER_NAME,
-  level: process.env.LOGGER_LEVEL
-} as LoggerConfiguration
-const loggerFactory = new LoggerFactory(loggerConfig)
+const loggerFactory = new LoggerFactory(configuration.logging)
 
 // Validators
 const ajv = new Ajv({
@@ -29,7 +21,7 @@ const validator = new AJVValidator(ajv, loggerFactory)
 
 // Repository
 const dynamoDB = new DynamoDB({
-  region: process.env.AWS_REGION,
+  region: configuration.aws.region,
   apiVersion: '2012-08-10'
 })
 const ddbRepository = new DynamoRepository(dynamoDB, loggerFactory)

--- a/src/models/configuration/AWSConfiguration.ts
+++ b/src/models/configuration/AWSConfiguration.ts
@@ -1,0 +1,8 @@
+/**
+ * Representation of the configuration required for AWS
+ */
+interface AWSConfiguration {
+  region: string
+}
+
+export { AWSConfiguration }

--- a/src/models/configuration/AppConfiguration.ts
+++ b/src/models/configuration/AppConfiguration.ts
@@ -1,0 +1,12 @@
+import { AWSConfiguration } from './AWSConfiguration'
+import { LoggerConfiguration } from './LoggerConfiguration'
+
+/**
+ * Representation of the configuration required by the application
+ */
+interface AppConfiguration {
+  aws: AWSConfiguration
+  logging: LoggerConfiguration
+}
+
+export { AppConfiguration }

--- a/src/models/configuration/LoggerConfiguration.ts
+++ b/src/models/configuration/LoggerConfiguration.ts
@@ -1,5 +1,5 @@
 /**
- * Representation of the configuration required by the logger factory
+ * Representation of the configuration required for logging
  */
 interface LoggerConfiguration {
   name: string

--- a/test/unit/factories/LoggerFactory.spec.ts
+++ b/test/unit/factories/LoggerFactory.spec.ts
@@ -1,7 +1,7 @@
 import * as Logger from 'bunyan'
 
 import { LoggerFactory } from '../../../src/factories/LoggerFactory'
-import { LoggerConfiguration } from '../../../src/models/LoggerConfiguration'
+import { LoggerConfiguration } from '../../../src/models/configuration/LoggerConfiguration'
 
 describe('LoggerFactory', () => {
   const config = {

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,8 @@
 {
   "extends": "tslint-config-standard",
   "rules": {
+    "eofline": true,
+    "newline-per-chained-call": true,
     "space-before-function-paren": false
   }
 }


### PR DESCRIPTION
Environment variables should be accessed once and from one place in the codebase. This configuration file should be imported/injected as and when required by the various layers. This helps to maintain and manage the environment variables available in the application

**Acceptance Criteria**
**Given** a developer,
**When** accessing environment variables,
**Then** all environment variables are available from a configuration file

[Ticket ESD-5](https://trello.com/c/J012jORy)